### PR TITLE
Halved cache reload response time

### DIFF
--- a/DFC.App.Triagetool.Services.CacheContentService.UnitTests/CmsReload/CmsReloadServiceTests.cs
+++ b/DFC.App.Triagetool.Services.CacheContentService.UnitTests/CmsReload/CmsReloadServiceTests.cs
@@ -22,7 +22,7 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
         private readonly IDocumentService<TriageToolOptionDocumentModel> fakeDocumentService = A.Fake<IDocumentService<TriageToolOptionDocumentModel>>();
         private readonly ICmsApiService fakeCmsApiService = A.Fake<ICmsApiService>();
         private readonly IContentTypeMappingService fakeContentTypeMappingService = A.Fake<IContentTypeMappingService>();
-        private readonly IApiCacheService fakeApiCacheService = A.Fake< IApiCacheService>();
+        private readonly IApiCacheService fakeApiCacheService = A.Fake<IApiCacheService>();
 
         [Fact]
         public async Task CacheReloadServiceReloadAllCancellationRequestedCancels()

--- a/DFC.App.Triagetool.Services.CacheContentService.UnitTests/CmsReload/CmsReloadServiceTests.cs
+++ b/DFC.App.Triagetool.Services.CacheContentService.UnitTests/CmsReload/CmsReloadServiceTests.cs
@@ -22,20 +22,23 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
         private readonly IDocumentService<TriageToolOptionDocumentModel> fakeDocumentService = A.Fake<IDocumentService<TriageToolOptionDocumentModel>>();
         private readonly ICmsApiService fakeCmsApiService = A.Fake<ICmsApiService>();
         private readonly IContentTypeMappingService fakeContentTypeMappingService = A.Fake<IContentTypeMappingService>();
+        private readonly IApiCacheService fakeApiCacheService = A.Fake< IApiCacheService>();
 
         [Fact]
         public async Task CacheReloadServiceReloadAllCancellationRequestedCancels()
         {
             //Arrange
             var cancellationToken = new CancellationToken(true);
-            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService);
+            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService, fakeApiCacheService);
 
             //Act
             await service.Reload(cancellationToken).ConfigureAwait(false);
 
             //Assert
+            A.CallTo(() => fakeApiCacheService.StartCache()).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionSummaryModel>(A<string>.Ignored, A<Guid>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeDocumentService.UpsertAsync(A<TriageToolOptionDocumentModel>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => fakeApiCacheService.StopCache()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -45,16 +48,18 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
             var dummyContentItem = A.Dummy<TriageToolOptionSummaryModel>();
 
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionSummaryModel>(A<string>.Ignored, A<Guid>.Ignored)).Returns(dummyContentItem);
-            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService);
+            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService, fakeApiCacheService);
 
             //Act
             await service.Reload(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
+            A.CallTo(() => fakeApiCacheService.StartCache()).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionItemModel>(A<string>.Ignored, A<Guid>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeDocumentService.UpsertAsync(A<TriageToolOptionDocumentModel>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetSummaryAsync<CmsApiSummaryItemModel>(CmsContentKeyHelper.PageTag)).MustNotHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetSummaryAsync<TriageToolOptionSummaryModel>(CmsContentKeyHelper.OptionTag)).MustHaveHappened();
+            A.CallTo(() => fakeApiCacheService.StopCache()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -74,7 +79,7 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
                 .Returns(GetValidApplicationViewSummary());
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionItemModel>(A<string>.Ignored, A<Guid>.Ignored)).Returns(GetValidOptionItem());
             A.CallTo(() => fakeCmsApiService.GetItemAsync<CmsApiDataModel>(A<Uri>.Ignored)).Returns(GetValidPage());
-            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService);
+            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService, fakeApiCacheService);
             A.CallTo(() => fakeMapper.Map<IList<PageDocumentModel>>(A<IList<CmsApiDataModel>>.Ignored))
                 .Returns(new List<PageDocumentModel> { GetPageDocumentModel(), });
             A.CallTo(() => fakeMapper.Map<IList<TriageToolOptionDocumentModel>>(A<IList<TriageToolOptionItemModel>>.Ignored))
@@ -84,10 +89,12 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
             await service.Reload(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
+            A.CallTo(() => fakeApiCacheService.StartCache()).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionItemModel>(A<Uri>.Ignored)).MustHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<CmsApiDataModel>(A<Uri>.Ignored)).MustHaveHappened();
             A.CallTo(() => fakeDocumentService.UpsertAsync(A<TriageToolOptionDocumentModel>.Ignored)).MustHaveHappened();
             A.CallTo(() => fakeDocumentService.PurgeAsync()).MustHaveHappened();
+            A.CallTo(() => fakeApiCacheService.StopCache()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -100,7 +107,7 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
                     fakeCmsApiService.GetSummaryAsync<TriageToolOptionSummaryModel>(CmsContentKeyHelper.OptionTag))
                 .Returns(options);
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionItemModel>(A<string>.Ignored, A<Guid>.Ignored)).Returns(GetValidOptionItem());
-            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService);
+            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService, fakeApiCacheService);
             A.CallTo(() => fakeMapper.Map<IList<PageDocumentModel>>(A<IList<CmsApiDataModel>>.Ignored))
                 .Returns(new List<PageDocumentModel> { GetPageDocumentModel(), });
             A.CallTo(() => fakeMapper.Map<IList<TriageToolOptionDocumentModel>>(A<IList<TriageToolOptionItemModel>>.Ignored))
@@ -110,11 +117,13 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
             await service.Reload(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
+            A.CallTo(() => fakeApiCacheService.StartCache()).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionItemModel>(A<Uri>.Ignored)).MustHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<CmsApiDataModel>(A<Uri>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeDocumentService.UpsertAsync(A<TriageToolOptionDocumentModel>.Ignored)).MustHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetSummaryAsync<CmsApiSummaryItemModel>(CmsContentKeyHelper.PageTag)).MustHaveHappened();
             A.CallTo(() => fakeCmsApiService.GetSummaryAsync<TriageToolOptionSummaryModel>(CmsContentKeyHelper.OptionTag)).MustHaveHappened();
+            A.CallTo(() => fakeApiCacheService.StopCache()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -122,7 +131,7 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
         {
             //Arrange
             var cancellationToken = new CancellationToken(true);
-            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService);
+            var service = new CacheReloadService(A.Fake<ILogger<CacheReloadService>>(), fakeMapper, fakeDocumentService, fakeCmsApiService, fakeContentTypeMappingService, fakeApiCacheService);
 
             A.CallTo(() =>
                     fakeCmsApiService.GetSummaryAsync<TriageToolOptionSummaryModel>(CmsContentKeyHelper.OptionTag))
@@ -132,8 +141,10 @@ namespace DFC.App.Triagetool.Services.CacheContentService.UnitTests.CmsReload
             await service.Reload(cancellationToken).ConfigureAwait(false);
 
             //Assert
+            A.CallTo(() => fakeApiCacheService.StartCache()).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeCmsApiService.GetItemAsync<TriageToolOptionSummaryModel>(A<string>.Ignored, A<Guid>.Ignored)).MustNotHaveHappened();
             A.CallTo(() => fakeDocumentService.UpsertAsync(A<TriageToolOptionDocumentModel>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => fakeApiCacheService.StopCache()).MustHaveHappenedOnceExactly();
         }
     }
 }

--- a/DFC.App.Triagetool/AutoMapperProfiles/CmsContentModelProfile.cs
+++ b/DFC.App.Triagetool/AutoMapperProfiles/CmsContentModelProfile.cs
@@ -34,6 +34,7 @@ namespace DFC.App.Triagetool.AutoMapperProfiles
             CreateMap<CmsTriageToolFilterModel, TriageToolFilterDocumentModel>();
 
             CreateMap<TriageToolOptionItemModel, TriageToolOptionDocumentModel>()
+                .ForMember(d => d.Id, s => s.MapFrom(m => m.ItemId))
                 .ForMember(d => d.Pages, s => s.Ignore())
                 .ForMember(d => d.FilterIds, s => s.MapFrom(m => m.ContentItems.Where(w => w.ContentType == CmsContentKeyHelper.FilterTag).Select(s => s.Url)))
                 .ForMember(d => d.PageIds, s => s.Ignore())

--- a/DFC.App.Triagetool/Startup.cs
+++ b/DFC.App.Triagetool/Startup.cs
@@ -12,6 +12,7 @@ using DFC.Content.Pkg.Netcore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -63,8 +64,9 @@ namespace DFC.App.Triagetool
         {
             var cosmosDbConnectionSharedContent = configuration.GetSection(CosmosDbSharedContentConfigAppSettings).Get<CosmosDbConnection>();
             var cosmosDbConnectionCmsContent = configuration.GetSection(CosmosDbCmsContentConfigAppSettings).Get<CosmosDbConnection>();
-            services.AddDocumentServices<SharedContentItemModel>(cosmosDbConnectionSharedContent, env.IsDevelopment());
-            services.AddDocumentServices<TriageToolOptionDocumentModel>(cosmosDbConnectionCmsContent, env.IsDevelopment());
+            var cosmosRetryOptions = new RetryOptions { MaxRetryAttemptsOnThrottledRequests = 20, MaxRetryWaitTimeInSeconds = 60 };
+            services.AddDocumentServices<SharedContentItemModel>(cosmosDbConnectionSharedContent, env.IsDevelopment(), cosmosRetryOptions);
+            services.AddDocumentServices<TriageToolOptionDocumentModel>(cosmosDbConnectionCmsContent, env.IsDevelopment(), cosmosRetryOptions);
 
             services.AddApplicationInsightsTelemetry();
             services.AddHttpContextAccessor();


### PR DESCRIPTION
Prevented duplicate items from being created by using ItemId from STAX as the TT option Id value